### PR TITLE
Fixed accel_plan step size if filterbank file is coherently dedispersed

### DIFF
--- a/include/utils/cmdline.hpp
+++ b/include/utils/cmdline.hpp
@@ -12,6 +12,7 @@ struct CmdLineOptions {
   unsigned int size;
   float dm_start;
   float dm_end;
+  float cdm;
   float dm_tol;
   float dm_pulse_width;
   std::string dm_file;
@@ -114,6 +115,10 @@ bool read_cmdline_options(CmdLineOptions& args, int argc, char **argv)
                                         "Last DM to dedisperse to",
                                         false, 0.0, "float", cmd);
 
+      TCLAP::ValueArg<float> arg_cdm("", "cdm",
+                                        "Coherently Dedispersed DM",
+                                        false, 0.0, "float", cmd);
+
       TCLAP::ValueArg<float> arg_dm_tol("", "dm_tol",
                                         "DM smearing tolerance (1.11=10%)",
                                         false, 1.11, "float",cmd);
@@ -196,7 +201,8 @@ bool read_cmdline_options(CmdLineOptions& args, int argc, char **argv)
       args.size              = arg_size.getValue();
       args.dm_file           = arg_dm_file.getValue();
       args.dm_end            = arg_dm_end.getValue();
-      args.dm_start            = arg_dm_start.getValue();
+      args.cdm               = arg_cdm.getValue();
+      args.dm_start          = arg_dm_start.getValue();
       args.dm_tol            = arg_dm_tol.getValue();
       args.dm_pulse_width    = arg_dm_pulse_width.getValue();
       args.host_ram_limit_gb = arg_host_ram_limit_gb.getValue();

--- a/include/utils/end_file_writer.hpp
+++ b/include/utils/end_file_writer.hpp
@@ -63,6 +63,7 @@ public:
     search_options.append(XML::Element("size",args.size));
     search_options.append(XML::Element("dm_start",args.dm_start));
     search_options.append(XML::Element("dm_end",args.dm_end));
+    search_options.append(XML::Element("cdm",args.cdm));
     search_options.append(XML::Element("dm_tol",args.dm_tol));
     search_options.append(XML::Element("dm_pulse_width",args.dm_pulse_width));
     search_options.append(XML::Element("acc_start",args.acc_start));

--- a/include/utils/output_stats.hpp
+++ b/include/utils/output_stats.hpp
@@ -81,6 +81,7 @@ public:
     search_options.append(XML::Element("dmfilename",args.dm_file));
     search_options.append(XML::Element("dm_start",args.dm_start));
     search_options.append(XML::Element("dm_end",args.dm_end));
+    search_options.append(XML::Element("cdm",args.cdm));
     search_options.append(XML::Element("dm_tol",args.dm_tol));
     search_options.append(XML::Element("dm_pulse_width",args.dm_pulse_width));
     search_options.append(XML::Element("acc_start",args.acc_start));
@@ -153,10 +154,10 @@ public:
     root.append(dm_trials);
   }
   
-  void add_acc_list(std::vector<float>& accs){
+  void add_acc_list(float cdm, std::vector<float>& accs){
     XML::Element acc_trials("acceleration_trials");
     acc_trials.add_attribute("count",accs.size());
-    acc_trials.add_attribute("DM",0);
+    acc_trials.add_attribute("DM", cdm);
     for(int ii=0;ii<accs.size();ii++){
       XML::Element trial("trial");
       trial.add_attribute("id",ii);

--- a/include/utils/utils.hpp
+++ b/include/utils/utils.hpp
@@ -158,7 +158,7 @@ public:
   {
   }
 
-  float dispersive_smear(float dm) const
+  float dispersive_smear(float dm, float cdm) const
   /*
    * Return the dispersive smear in seconds
    */
@@ -166,26 +166,26 @@ public:
     // Frequencies need to be converted to GHz
     float ftop = (cfreq + ch_bw/2) / 1e9;
     float fbottom = (cfreq - ch_bw/2) / 1e9;
-    return 4.15e-3 * (1/(fbottom * fbottom) - 1/(ftop * ftop)) * dm;
+    return 4.15e-3 * (1/(fbottom * fbottom) - 1/(ftop * ftop)) * fabs(cdm - dm);
   }
 
-  float pulse_broadening(float dm) const
+  float pulse_broadening(float dm, float cdm) const
   /*
    * Return the pulse broadinging for a given dm in seconds
    */
   {
-    float tdm = this->dispersive_smear(dm);
+    float tdm = this->dispersive_smear(dm, cdm);
     //cout << "Dispersive smear (s): " << tdm << "\n";
     return sqrt((tdm * tdm) + (pulse_width * pulse_width) + (tsamp * tsamp));
   }
 
-  float accel_step(float dm) const
+  float accel_step(float dm, float cdm) const
   /*
    * Return the optimal acceleration step in m/s/s
    */
 
   {
-    float broadening = this->pulse_broadening(dm);
+    float broadening = this->pulse_broadening(dm, cdm);
     //cout << "Total broadening (s): " << broadening << "\n";
     float factor = sqrt((tol * tol) - 1.0);
     float tobs = nsamps * tsamp;
@@ -194,6 +194,7 @@ public:
 
   void generate_accel_list(
     float dm,
+    float cdm,
     std::vector<float>& acc_list) const
   /*
    * Return the acceleration list for the
@@ -211,7 +212,7 @@ public:
       acc_list.push_back(0.0f);
     }
 
-    float step = this->accel_step(dm);
+    float step = this->accel_step(dm, cdm);
     //cout << "Acceleration step (m/s/s): " << step << "\n";
     float acc = acc_lo;
     while (acc <= acc_hi)

--- a/src/pipeline_multi.cu
+++ b/src/pipeline_multi.cu
@@ -133,6 +133,15 @@ public:
     TimeDomainResampler resampler;
     DevicePowerSpectrum<float> pspec(d_fseries);
     Zapper* bzap;
+    // If filterbank file is coherently dedispersed at a non-zero value
+    float cdm = args.cdm;
+    if (args.verbose)
+        if (cdm != 0.0)
+	        std::cout << "Filterbank file is coherently dedispersed at DM: " << args.cdm << ". Will adjust acceleration trial step size accordingly. " << std::endl; 
+        else
+            std::cout << "Filterbank file is not coherently dedispersed. " << std::endl;
+        
+    
     if (args.zapfilename!=""){
       if (args.verbose)
 	      std::cout << "Using zapfile: " << args.zapfilename << std::endl;
@@ -184,10 +193,10 @@ public:
             }
 	    //padding_mean = stats::mean<float>(d_tim.get_data(),trials.get_nsamps());
       }
-
+      
       if (args.verbose)
 	    std::cout << "Generating accelration list" << std::endl;
-      acc_plan.generate_accel_list(tim.get_dm(),acc_list);
+      acc_plan.generate_accel_list(tim.get_dm(), cdm, acc_list);
 
       if (args.verbose)
 	    std::cout << "Searching "<< acc_list.size()<< " acceleration trials for DM "<< tim.get_dm() << std::endl;
@@ -543,8 +552,11 @@ int main(int argc, char **argv)
   stats.add_dm_list(full_dm_list);
 
   std::vector<float> acc_list;
-  acc_plan.generate_accel_list(0.0,acc_list);
-  stats.add_acc_list(acc_list);
+  // If filterbank file is coherently dedispersed at a non-zero value
+  float cdm = args.cdm;
+  //acc_plan.generate_accel_list(0.0,cdm,acc_list);
+  acc_plan.generate_accel_list(cdm, cdm, acc_list);
+  stats.add_acc_list(cdm, acc_list);
 
   std::vector<int> device_idxs;
   for (int device_idx=0;device_idx<nthreads;device_idx++)


### PR DESCRIPTION
The user now has the option to give a non-zero coherently dedispersed value as input argument (e,g: --cdm 250.0).
I tested the acceleration step size on real data. As expected step size goes down the closer you get to cdm.

By default, it should be equivalent to the old version with coherently dedispersed DM (cdm) = 0. So there should be no breaking changes. CDM value if used is also reflected in the output XML file.