### PR TITLE
Optionally dump dedispersed timeseries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,16 +28,18 @@ CFLAGS    = ${UCFLAGS} -fPIC ${OPTIMISE} ${DEBUG}
 OBJECTS   = ${OBJ_DIR}/kernels.o
 EXE_FILES = ${BIN_DIR}/peasoup
 
-all: directories ${OBJECTS} ${EXE_FILES}
+all: directories ${OBJECTS} ${EXE_FILES} 
 
 ${OBJ_DIR}/kernels.o: ${SRC_DIR}/kernels.cu
 	${NVCC} -c ${NVCCFLAGS} ${INCLUDE} $<  -o $@
 
-${BIN_DIR}/peasoup: ${SRC_DIR}/pipeline_multi.cu ${OBJECTS}
+${BIN_DIR}/peasoup: ${SRC_DIR}/pipeline_multi.cu  ${SRC_DIR}/utils.cpp ${OBJECTS}
 	${NVCC} ${NVCCFLAGS} ${INCLUDE} ${LIBS} $^ -o $@
 
 ${BIN_DIR}/ffaster: ${SRC_DIR}/ffa_pipeline.cu ${OBJECTS}
 	${NVCC} ${NVCCFLAGS_FFA} ${INCLUDE} ${FFASTER_INCLUDES} ${LIBS} $^ -o $@
+
+
 
 directories:
 	@mkdir -p ${BIN_DIR}

--- a/include/data_types/filterbank.hpp
+++ b/include/data_types/filterbank.hpp
@@ -326,6 +326,10 @@ public:
     return nsamps_read;
   }
 
+  SigprocHeader get_header() {
+    return this->_header;
+  }
+
 
 
   double get_segment_pepoch() {

--- a/include/data_types/presto_timeseries.hpp
+++ b/include/data_types/presto_timeseries.hpp
@@ -1,0 +1,8 @@
+
+class PrestoTimeSeries{
+    public: 
+        PrestoTimeSeries(){};
+        wite
+        
+
+}

--- a/include/data_types/presto_timeseries.hpp
+++ b/include/data_types/presto_timeseries.hpp
@@ -1,8 +1,0 @@
-
-class PrestoTimeSeries{
-    public: 
-        PrestoTimeSeries(){};
-        wite
-        
-
-}

--- a/include/data_types/timeseries.hpp
+++ b/include/data_types/timeseries.hpp
@@ -562,11 +562,12 @@ public:
 
   }
 
-  void write_timeseries_to_file(std::string filename_prefix, std::size_t idx, SigprocHeader hdr){
+  void write_timeseries_to_file(std::string outdir, std::string filename_prefix, std::size_t idx, SigprocHeader hdr){
     T* ptr = this->get_data_ptr() + (size_t)idx*(size_t)this->nsamps;
     double dm = dm_list[idx];
     std::ofstream outfile;
     std::stringstream file_prefix;
+    file_prefix << outdir << "/";
     file_prefix << filename_prefix  << "_DM" << std::setw(9) << std::setfill('0') << std::fixed << std::setprecision(3) << dm;
 
     std::stringstream dat_file_name;

--- a/include/data_types/timeseries.hpp
+++ b/include/data_types/timeseries.hpp
@@ -39,6 +39,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <pwd.h>
+#include <cmath>
 #include "kernels/kernels.h"
 #include "kernels/defaults.h"
 
@@ -525,7 +526,7 @@ public:
 
       double bw = hdr.foff * hdr.nchans;
 
-      double lowest_freq = bw < 0 ? hdr.fch1 + bw * (hdr.nchans - 1) : hdr.fch1;
+      double lowest_freq =  hdr.foff < 0 ? hdr.fch1 + hdr.foff * (hdr.nchans -1)  : hdr.fch1;
 
  
 
@@ -546,9 +547,9 @@ public:
       ss << " Type of observation (EM band)          =  Radio\n";
       ss << " Dispersion measure (cm-3 pc)           =  " << hdr.refdm << "\n";
       ss << " Central freq of low channel (Mhz)      =  " << lowest_freq << "\n";
-      ss << " Total bandwidth (Mhz)                  =  " << std::fixed << std::setprecision(6) << bw << "\n";        
+      ss << " Total bandwidth (Mhz)                  =  " << std::fixed << std::setprecision(6) << abs(bw) << "\n";        
       ss << " Number of channels                     =  " << 1 << "\n";
-      ss << " Channel bandwidth (Mhz)                =  " << bw << "\n";
+      ss << " Channel bandwidth (Mhz)                =  " << abs(bw) << "\n";
       ss << " Data analyzed by                       =  " << login << "\n";
       ss << " Any additional notes:\n";
       ss    << "    File written by Peasoup pulsar search package\n";

--- a/include/utils/cmdline.hpp
+++ b/include/utils/cmdline.hpp
@@ -36,6 +36,7 @@ struct CmdLineOptions {
   bool progress_bar;
   long  start_sample;
   long nsamples;
+  std::string dump_time_series_to;
 };
 
 struct FFACmdLineOptions {
@@ -198,7 +199,11 @@ bool read_cmdline_options(CmdLineOptions& args, int argc, char **argv)
 
       TCLAP::ValueArg<unsigned int> arg_nsamples("", "nsamples",
 						 "Only take this many samples from start sample. Default: Until EOF",
-						 false, 0, "long", cmd);        
+						 false, 0, "long", cmd);     
+             
+      TCLAP::ValueArg<std::string> arg_dump_time_series_to("d", "dump_time_series_to",
+        "dump dedispersed time series to this directory",
+        false, get_utc_str(), "string",cmd);
 
       cmd.parse(argc, argv);
       args.infilename        = arg_infilename.getValue();
@@ -233,6 +238,7 @@ bool read_cmdline_options(CmdLineOptions& args, int argc, char **argv)
       args.progress_bar      = arg_progress_bar.getValue();
       args.start_sample      = arg_start_sample.getValue();
       args.nsamples           = arg_nsamples.getValue();
+      args.dump_time_series_to = arg_dump_time_series_to.getValue();
 
     }catch (TCLAP::ArgException &e) {
     std::cerr << "Error: " << e.error() << " for arg " << e.argId()

--- a/include/utils/cmdline.hpp
+++ b/include/utils/cmdline.hpp
@@ -36,7 +36,8 @@ struct CmdLineOptions {
   bool progress_bar;
   long  start_sample;
   long nsamples;
-  std::string dump_time_series_to;
+  std::string timeseries_dump_dir;
+  bool no_search;
 };
 
 struct FFACmdLineOptions {
@@ -201,9 +202,14 @@ bool read_cmdline_options(CmdLineOptions& args, int argc, char **argv)
 						 "Only take this many samples from start sample. Default: Until EOF",
 						 false, 0, "long", cmd);     
              
-      TCLAP::ValueArg<std::string> arg_dump_time_series_to("d", "dump_time_series_to",
+      TCLAP::ValueArg<std::string> arg_timeseries_dump_dir("d", "timeseries_dump_dir",
         "dump dedispersed time series to this directory",
-        false, get_utc_str(), "string",cmd);
+        false, "", "string",cmd);
+
+       TCLAP::SwitchArg arg_no_search("", "nosearch", "Do not search while dumping timeseries, no effect otherwise", cmd);
+
+
+      
 
       cmd.parse(argc, argv);
       args.infilename        = arg_infilename.getValue();
@@ -238,7 +244,8 @@ bool read_cmdline_options(CmdLineOptions& args, int argc, char **argv)
       args.progress_bar      = arg_progress_bar.getValue();
       args.start_sample      = arg_start_sample.getValue();
       args.nsamples           = arg_nsamples.getValue();
-      args.dump_time_series_to = arg_dump_time_series_to.getValue();
+      args.timeseries_dump_dir = arg_timeseries_dump_dir.getValue();
+      args.no_search         = arg_no_search.getValue();
 
     }catch (TCLAP::ArgException &e) {
     std::cerr << "Error: " << e.error() << " for arg " << e.argId()

--- a/include/utils/utils.hpp
+++ b/include/utils/utils.hpp
@@ -4,6 +4,8 @@
 #include <string>
 #include <utils/exceptions.hpp>
 #include <fstream>
+#include <sstream>
+#include <iomanip>
 #include <vector>
 #include <algorithm>
 #include <iostream>
@@ -229,5 +231,6 @@ public:
     return;
   }
 };
-
+void sigproc_to_ddmmss(double sigproc, std::string& ddmmss);
+void sigproc_to_hhmmss(double sigproc, std::string& hhmmss);
 

--- a/src/pipeline_multi.cu
+++ b/src/pipeline_multi.cu
@@ -362,6 +362,7 @@ int main(int argc, char **argv)
   if (args.verbose)
     std::cout << "Using file: " << args.infilename << std::endl;
   std::string filename(args.infilename);
+  std::string filename_without_ext = filename.substr(0,filename.find_last_of("."));
 
   //Stopwatch timer;
   if (args.progress_bar)
@@ -496,11 +497,16 @@ int main(int argc, char **argv)
     if (args.progress_bar)
       dispenser.enable_progress_bar();
 
-    for (int ii=0;ii<dm_list_chunk.size();ii++){
-      trials.write_timeseries_to_file("test", ii, header);
+    // if args.dump_time_series_to is not empty, write the time series to file
 
+    if (args.dump_time_series_to != ""){
+      for (int ii=0;ii<dm_list_chunk.size();ii++){
+        trials.write_timeseries_to_file(args.dump_time_series_to, filename_without_ext, ii, header);
+      }
     }
 
+   
+    
     for (int ii=0;ii<nthreads;ii++){
       workers[ii] = (new Worker(trials,dispenser,acc_plan,args,size,ii));
       pthread_create(&threads[ii], NULL, launch_worker_thread, (void*) workers[ii]);

--- a/src/pipeline_multi.cu
+++ b/src/pipeline_multi.cu
@@ -30,6 +30,7 @@
 #include "cufft.h"
 #include "pthread.h"
 #include <cmath>
+#include <filesystem>
 #include <map>
 
 typedef float DedispOutputType;
@@ -362,7 +363,11 @@ int main(int argc, char **argv)
   if (args.verbose)
     std::cout << "Using file: " << args.infilename << std::endl;
   std::string filename(args.infilename);
-  std::string filename_without_ext = filename.substr(0,filename.find_last_of("."));
+  std::filesystem::path filpath = filename;
+
+  if(args.timeseries_dump_dir == "" && args.no_search){
+    std::cout << "-nosearch is only useful if you are only dumping timeseries. Otherwise it does nothing." << std::endl;
+  }
 
   //Stopwatch timer;
   if (args.progress_bar)
@@ -497,11 +502,19 @@ int main(int argc, char **argv)
     if (args.progress_bar)
       dispenser.enable_progress_bar();
 
-    // if args.dump_time_series_to is not empty, write the time series to file
+    // if args.timeseries_dump_dir is not empty, write the time series to file
 
-    if (args.dump_time_series_to != ""){
+    std::cout << "Dumping time series to " << args.timeseries_dump_dir << std::endl;
+    std::cout << "filename without ext: " << filpath.stem().string() << std::endl;
+
+    if (args.timeseries_dump_dir != ""){
+      std::filesystem::create_directories(args.timeseries_dump_dir);
       for (int ii=0;ii<dm_list_chunk.size();ii++){
-        trials.write_timeseries_to_file(args.dump_time_series_to, filename_without_ext, ii, header);
+        trials.write_timeseries_to_file(args.timeseries_dump_dir, filpath.stem().string(), ii, header);
+      }
+      if(args.no_search){
+        std::cout << "No search requested, exiting" << std::endl;
+        return 0;
       }
     }
 

--- a/src/pipeline_multi.cu
+++ b/src/pipeline_multi.cu
@@ -1,5 +1,6 @@
 #include <data_types/timeseries.hpp>
 #include <data_types/fourierseries.hpp>
+#include <data_types/header.hpp>
 #include <data_types/candidates.hpp>
 #include <data_types/filterbank.hpp>
 #include <transforms/dedisperser.hpp>
@@ -374,6 +375,7 @@ int main(int argc, char **argv)
 
   timers["reading"].start();
   SigprocFilterbank filobj(filename, args.start_sample, args.nsamples);
+  SigprocHeader header = filobj.get_header();
   timers["reading"].stop();
 
   if (args.progress_bar){
@@ -493,6 +495,11 @@ int main(int argc, char **argv)
     DMDispenser dispenser(trials);
     if (args.progress_bar)
       dispenser.enable_progress_bar();
+
+    for (int ii=0;ii<dm_list_chunk.size();ii++){
+      trials.write_timeseries_to_file("test", ii, header);
+
+    }
 
     for (int ii=0;ii<nthreads;ii++){
       workers[ii] = (new Worker(trials,dispenser,acc_plan,args,size,ii));

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,0 +1,77 @@
+#include <utils/utils.hpp>
+
+/**
+ * @brief Parses the angle in sigproc format.
+ *
+ * This function takes a sigproc angle and parses it into its components.
+ *
+ * @param sigproc The sigproc angle to be parsed.
+ * @param sign The sign of the angle (-1 for negative, 1 for positive).
+ * @param first The first component of the angle.
+ * @param second The second component of the angle.
+ * @param third The third component of the angle.
+ */
+ void parse_angle_sigproc(double sigproc, int& sign, int& first, int& second, double& third)
+ {
+ 
+     sign = sigproc < 0 ? -1 : 1;
+     double abs_sigproc = std::abs(sigproc);
+ 
+     first = (int)(abs_sigproc / 1e4);
+     second = (int)((abs_sigproc - first * 1e4) / 1e2);
+     third = abs_sigproc - first * 1e4 - second * 1e2;
+ 
+ }
+  /**
+ * Converts a sigproc value to HH:MM:SS format.
+ *
+ * @param sigproc The sigproc value to convert. This has the format of HHMMSS
+ * @param hhmmss  The resulting HH:MM:SS string.
+ */
+void sigproc_to_hhmmss(double sigproc, std::string& hhmmss)
+{ 
+    int sign, hh, mm;
+    double ss;
+    parse_angle_sigproc(sigproc, sign, hh, mm, ss);
+
+    std::stringstream sstream;
+    sstream << std::setw(2) << std::setfill('0') << std::fixed << std::setprecision(0) << hh;
+    sstream << ":";
+    sstream << std::setw(2) << std::setfill('0') << std::fixed << std::setprecision(0) << mm;
+    sstream << ":";
+    sstream << std::setw(2) << std::setfill('0') << std::fixed << std::setprecision(2) << ss;
+
+    hhmmss = sstream.str();
+   
+}
+
+/**
+ * Converts a signal processing value to a string representation in the format "dd:mm:ss".
+ * 
+ * @param sigproc The signal processing value to convert.
+ * @param ddmmss  The resulting string representation in the format "dd:mm:ss".
+ */
+void sigproc_to_ddmmss(double sigproc, std::string& ddmmss)
+{
+    int sign, dd, mm;
+    double ss;
+    parse_angle_sigproc(sigproc, sign, dd, mm, ss);
+
+    std::stringstream sstream;
+    if (sign < 0)
+    {
+        sstream << std::setw(1) << "-";
+    }
+
+    sstream << std::setw(2) << std::setfill('0') << std::fixed << std::setprecision(0) << dd;
+    sstream << ":";
+    sstream << std::setw(2) << std::setfill('0') << std::fixed << std::setprecision(0) << mm;
+    sstream << ":";
+    sstream << std::setw(2) << std::setfill('0') << std::fixed << std::setprecision(2) << ss;
+
+    ddmmss = sstream.str();
+   
+}
+
+
+


### PR DESCRIPTION
I have added an option to write out presto timeseries files from the dedispered output. 
This is triggered via the `-d` flag which takes in the output directory to put the output `.dat` and `.inf` files. 

If timeseries dumping is the only thing to be done, there is an additional `--nosearch` flag which will quit the application after dedispersion. This will make it similar to `prepdata`. 

I have tested this on a sample COMPACT filterbank containing J1909-3744. Attached images are the folds of the filterbank and the corresponding timeseries - both the discovery DM and period of a  periodicity search of the same filterbank. 

Thanks,
Vivek
![image](https://github.com/user-attachments/assets/b40da211-0d8b-4004-9557-b0314387a2ee)
![image](https://github.com/user-attachments/assets/1039d86d-a5d8-40ed-8c7c-2f5401844a92)
